### PR TITLE
Added constructor parameters for EEGDataTransformer

### DIFF
--- a/src/main/java/cz/zcu/kiv/signal/EEGDataTransformer.java
+++ b/src/main/java/cz/zcu/kiv/signal/EEGDataTransformer.java
@@ -12,11 +12,23 @@ import java.util.List;
 public class EEGDataTransformer implements DataTransformer {
 
     private VhdrReader reader = new VhdrReader();
-    private final String HDFS_URI = "hdfs://localhost:8020";
-    private  final Configuration HDFS_CONF = new Configuration();
+    private String hdfsURI;
+    private Configuration hdfsConfiguration;
 
     // this will be a copy of the hadoop filesystem that we can later re-use
     private FileSystem fs;
+
+    /**
+     * Constructor
+     * Initializes the URI and configugration of the HDFS to use.
+     *
+     * @param hdfsURI - the HDFS URI passed as a string e.g. "hdfs://localhost:8020"
+     * @param hdfsConfiguration - the HDFS Configuration object
+     */
+    public EEGDataTransformer(String hdfsURI, Configuration hdfsConfiguration){
+        this.hdfsURI = hdfsURI;
+        this.hdfsConfiguration = hdfsConfiguration;
+    }
 
     /**
      * This method reads binary data and decodes double values.
@@ -103,7 +115,7 @@ public class EEGDataTransformer implements DataTransformer {
     }
 
     private byte[] fileToByteArray(String filename) throws IOException {
-        this.fs = FileSystem.get(URI.create(HDFS_URI), HDFS_CONF);
+        this.fs = FileSystem.get(URI.create(hdfsURI), hdfsConfiguration);
         FSDataInputStream data = fs.open(new Path(filename));
 
         byte[] fileArray = new byte[(int) fs.getFileLinkStatus(new Path(filename)).getLen()];

--- a/src/main/java/cz/zcu/kiv/signal/EEGDataTransformer.java
+++ b/src/main/java/cz/zcu/kiv/signal/EEGDataTransformer.java
@@ -20,7 +20,7 @@ public class EEGDataTransformer implements DataTransformer {
 
     /**
      * Constructor
-     * Initializes the URI and configugration of the HDFS to use.
+     * Initializes the URI and configuration of the HDFS to use.
      *
      * @param hdfsURI - the HDFS URI passed as a string e.g. "hdfs://localhost:8020"
      * @param hdfsConfiguration - the HDFS Configuration object
@@ -28,6 +28,15 @@ public class EEGDataTransformer implements DataTransformer {
     public EEGDataTransformer(String hdfsURI, Configuration hdfsConfiguration){
         this.hdfsURI = hdfsURI;
         this.hdfsConfiguration = hdfsConfiguration;
+    }
+
+    /**
+     * Default Constructor
+     * Initializes the URI and configuration of the HDFS to use with defaults.
+     */
+    public EEGDataTransformer(){
+        this.hdfsURI = "http://localhost:8020";
+        this.hdfsConfiguration = new Configuration();
     }
 
     /**

--- a/src/main/java/cz/zcu/kiv/test/Main.java
+++ b/src/main/java/cz/zcu/kiv/test/Main.java
@@ -3,6 +3,7 @@ package cz.zcu.kiv.test;
 import cz.zcu.kiv.signal.ChannelInfo;
 import cz.zcu.kiv.signal.DataTransformer;
 import cz.zcu.kiv.signal.EEGDataTransformer;
+import org.apache.hadoop.conf.Configuration;
 
 import java.nio.ByteOrder;
 import java.util.List;
@@ -16,10 +17,12 @@ import java.util.List;
  */
 public class Main {
 
+    private static final String HDFS_URI = "hdfs://localhost:8020";
+    private static final Configuration HDFS_CONF = new Configuration();
 
     public static void main(String[] args)  {
         try {
-            DataTransformer transformer = new EEGDataTransformer();
+            DataTransformer transformer = new EEGDataTransformer(HDFS_URI,HDFS_CONF);
             //List<EEGMarker> list = transformer.readMarkerList("c:\\java\\guess_the_number\\data\\numbers\\Blatnice\\blatnice20141023_9.vmrk");
             List<ChannelInfo> channels = transformer.getChannelInfo(args[0]);
             int channel = Integer.parseInt(args[args.length-1]);


### PR DESCRIPTION
Added URI and configuration parameters to the constructor of EEGDataTransformer to avoid usage of the values that were hardcoded earlier. The hardcoded value did not allow code using the library to access remote clusters.